### PR TITLE
Add Telegram media bot deployment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg curl && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV PORT=8080
+CMD ["uvicorn","main:app","--host=0.0.0.0","--port=8080"]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,54 @@
+import os, asyncio, tempfile, subprocess, requests
+from pathlib import Path
+from fastapi import FastAPI, Request, HTTPException
+from fastapi.responses import JSONResponse
+from aiogram import Bot, Dispatcher, types
+from aiogram.enums import ParseMode
+
+TELEGRAM_TOKEN = os.environ["TELEGRAM_TOKEN"]
+WEBHOOK_SECRET = TELEGRAM_TOKEN
+APP_URL = os.environ.get("APP_URL", "")
+PORT = int(os.environ.get("PORT", "8080"))
+
+bot = Bot(token=TELEGRAM_TOKEN, parse_mode=ParseMode.HTML)
+dp = Dispatcher()
+app = FastAPI()
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+async def save_file(file_id: str, suffix: str) -> str:
+    f = await bot.get_file(file_id)
+    fd, path = tempfile.mkstemp(suffix=suffix); os.close(fd)
+    url = f"https://api.telegram.org/file/bot{TELEGRAM_TOKEN}/{f.file_path}"
+    with requests.get(url, stream=True) as r, open(path, "wb") as out:
+        r.raise_for_status()
+        for chunk in r.iter_content(1<<14): out.write(chunk)
+    return path
+
+def transcode_to_wav(src: str) -> str:
+    dst = Path(src).with_suffix(".wav")
+    subprocess.check_call(["ffmpeg","-y","-i",src,"-ar","16000","-ac","1",str(dst)])
+    return str(dst)
+
+@dp.message()
+async def handle_message(message: types.Message):
+    if message.voice:
+        src = await save_file(message.voice.file_id, ".ogg")
+        wav = transcode_to_wav(src)
+        await message.reply("📝 Transcoding done. (Hook Whisper here) -> " + os.path.basename(wav))
+        return
+    await message.reply(f"👋 Echo: {message.text or 'no text'}")
+
+@app.post(f"/webhook/{{secret}}")
+async def telegram_webhook(secret: str, request: Request):
+    if secret != WEBHOOK_SECRET:
+        raise HTTPException(status_code=403, detail="forbidden")
+    update = types.Update.model_validate(await request.json(), strict=False)
+    await dp.feed_update(bot, update)
+    return JSONResponse({"ok": True})
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("main:app", host="0.0.0.0", port=PORT, reload=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.111.0
+uvicorn==0.30.1
+aiogram==3.8.0
+requests==2.32.3

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+PROJECT_ID="${PROJECT_ID:-PROJECT_ID_PLACEHOLDER}"
+REGION="${REGION:-REGION_PLACEHOLDER}"
+SERVICE="telegram-bot"
+IMAGE="gcr.io/${PROJECT_ID}/${SERVICE}"
+
+[[ "$PROJECT_ID" == "PROJECT_ID_PLACEHOLDER" || "$REGION" == "REGION_PLACEHOLDER" ]] && \
+  { echo "Set PROJECT_ID and REGION env vars or replace placeholders."; exit 1; }
+
+echo "Enabling APIs..."
+gcloud services enable run.googleapis.com secretmanager.googleapis.com cloudbuild.googleapis.com --project "$PROJECT_ID"
+
+echo "Creating/Updating secret telegram-token..."
+if gcloud secrets describe telegram-token --project "$PROJECT_ID" >/dev/null 2>&1; then
+  echo -n "${TELEGRAM_TOKEN:?missing TELEGRAM_TOKEN}" | gcloud secrets versions add telegram-token --project "$PROJECT_ID" --data-file=-
+else
+  echo -n "${TELEGRAM_TOKEN:?missing TELEGRAM_TOKEN}" | gcloud secrets create telegram-token --project "$PROJECT_ID" --data-file=-
+fi
+
+echo "Building image ${IMAGE}..."
+gcloud builds submit --project "$PROJECT_ID" --tag "$IMAGE"
+
+echo "Deploying to Cloud Run..."
+gcloud run deploy "$SERVICE" \
+  --image "$IMAGE" \
+  --project "$PROJECT_ID" \
+  --platform managed \
+  --region "$REGION" \
+  --allow-unauthenticated \
+  --max-instances=2 \
+  --set-secrets TELEGRAM_TOKEN=telegram-token:latest
+
+URL=$(gcloud run services describe "$SERVICE" --project "$PROJECT_ID" --region "$REGION" --format='value(status.url)')
+echo "Service URL: $URL"
+
+echo "Saving APP_URL env var (for future use)..."
+gcloud run services update "$SERVICE" --project "$PROJECT_ID" --region "$REGION" --set-env-vars APP_URL="${URL}"
+
+TOKEN="$(gcloud secrets versions access latest --secret=telegram-token --project "$PROJECT_ID")"
+echo "Setting Telegram webhook..."
+curl -fsS "https://api.telegram.org/bot${TOKEN}/setWebhook?url=${URL}/webhook/${TOKEN}" | sed -E 's/.*/Webhook set: &/'
+
+echo "Webhook info:"
+curl -fsS "https://api.telegram.org/bot${TOKEN}/getWebhookInfo"; echo
+
+echo "Health check:"
+curl -fsS "${URL}/health"; echo

--- a/scripts/unset_webhook.sh
+++ b/scripts/unset_webhook.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+PROJECT_ID="${PROJECT_ID:?}"; REGION="${REGION:?}"; SERVICE="telegram-bot"
+TOKEN="$(gcloud secrets versions access latest --secret=telegram-token --project "$PROJECT_ID")"
+curl -fsS "https://api.telegram.org/bot${TOKEN}/deleteWebhook?drop_pending_updates=true"
+echo


### PR DESCRIPTION
## Summary
- Relocate Telegram bot application, Dockerfile, and requirements to the repository root so Cloud Build can detect the Dockerfile
- FastAPI + aiogram bot serves `/health` and secret-protected `/webhook/<token>` endpoints and transcodes voice notes via FFmpeg
- Deployment scripts manage Cloud Run deployment and Telegram webhook using Secret Manager

## Testing
- `python -m py_compile main.py`
- `./scripts/deploy.sh` *(fails: gcloud: command not found)*
- `apt-get install -y google-cloud-sdk` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689f0cf04d34832193e4ab5aa72c1b1b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces a FastAPI-based service with a health check and a secured Telegram webhook.
  - Processes text and voice messages; downloads voice notes, transcodes to WAV, and replies to users.

- DevOps
  - Adds containerization with a slim Python base and FFmpeg for media handling.
  - Provides deployment automation to Google Cloud Run with secret management, webhook setup, and post-deploy health checks.
  - Includes a utility to unset the Telegram webhook.

- Chores
  - Pins application dependencies.
  - Updates ignore rules for Python artifacts and environment files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->